### PR TITLE
Update StylingRulesOfThumb.py

### DIFF
--- a/docs/getting_started/StylingRulesOfThumb.py
+++ b/docs/getting_started/StylingRulesOfThumb.py
@@ -56,7 +56,7 @@ def button_section():
                 LabelInput("Name"), 
                 cols=2), 
            Grid(Button("Submit Information", cls=ButtonT.primary),
-                Button("Delete Information", cls=ButtonT.danger),
+                Button("Delete Information", cls=ButtonT.destructive),
                 Button("Cancel"),
                 cols=3)
        )
@@ -68,7 +68,7 @@ def button_section():
         List(
             Li("Use ButtonT.primary for the most important actions (ie add to card, checkout, etc.)"),
             Li("Use ButtonT.secondary for actions that are important but not the primary action (ie save, etc.)"),
-            Li("Use ButtonT.danger for destructive actions"),
+            Li("Use ButtonT.destructive for destructive actions"),
             Li("Use default styling for UX actions (ie go cancel, close etc.)"),
             cls=ListT.bullet
         ),


### PR DESCRIPTION
Updating `ButtonT.danger` to `ButtonT.destructive` to reflect https://github.com/AnswerDotAI/MonsterUI/commit/b5d8b7d2517f42b62c5e2dad2f2dfe2f4c109cce#diff-30d96aa9f2da8ccd9001dcf1b926579a84b75912a7d7f4448b10ecf28578d9caL46

There are a few other uses of "danger" that we may or may not want to change to "destructive" for consistency, but this appears to be the only use of a `ButtonT.danger` attribute that no longer exists: https://github.com/search?q=repo%3AAnswerDotAI%2FMonsterUI%20danger&type=code.

It would be nice to have GitHub Actions execute the docs code and raise exceptions, but it might be premature at least for this file.